### PR TITLE
Define (<>) in Semigroup instance

### DIFF
--- a/library/ByteString/TreeBuilder.hs
+++ b/library/ByteString/TreeBuilder.hs
@@ -55,6 +55,9 @@ instance Semigroup Builder where
   sconcat =
     foldl' mappend mempty
 
+  {-# INLINABLE (<>) #-}
+  (<>) = mappend
+
 instance IsString Builder where
   {-# INLINE fromString #-}
   fromString string =


### PR DESCRIPTION
Prevents "No instance nor default method for class operation <>" runtime (!) error.

I have no idea why it's not using the default

```haskell
default (<>) :: Monoid a => a -> a -> a
(<>) = mappend
```

Maybe defaults aren't used if you do define a custom instance...