### PR TITLE
Address GHC 9.8 portability

### DIFF
--- a/library/ByteString/TreeBuilder.hs
+++ b/library/ByteString/TreeBuilder.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module ByteString.TreeBuilder
 (
   Builder,
@@ -43,9 +44,10 @@ instance Monoid Builder where
   {-# INLINE mempty #-}
   mempty =
     Builder 0 A.Empty
+#if !(MIN_VERSION_base(4,11,0))
   {-# INLINABLE mappend #-}
-  mappend (Builder length1 tree1) (Builder length2 tree2) =
-    Builder (length1 + length2) (A.Branch tree1 tree2)
+  mappend = (<>)
+#endif
   {-# INLINE mconcat #-}
   mconcat =
     foldl' mappend mempty
@@ -56,7 +58,8 @@ instance Semigroup Builder where
     foldl' mappend mempty
 
   {-# INLINABLE (<>) #-}
-  (<>) = mappend
+  (Builder length1 tree1) <> (Builder length2 tree2) =
+    Builder (length1 + length2) (A.Branch tree1 tree2)
 
 instance IsString Builder where
   {-# INLINE fromString #-}

--- a/library/ByteString/TreeBuilder/Poker.hs
+++ b/library/ByteString/TreeBuilder/Poker.hs
@@ -15,7 +15,7 @@ pokeBytes :: ByteString -> Ptr Word8 -> IO (Ptr Word8)
 pokeBytes (B.PS foreignPointer offset length) pointer =
   do
     withForeignPtr foreignPointer $ \pointer' ->
-      B.memcpy pointer (plusPtr pointer' offset) length
+      copyBytes pointer (plusPtr pointer' offset) length
     pure (plusPtr pointer length)
 
 -- |
@@ -25,7 +25,7 @@ pokeBytesMinus :: ByteString -> Ptr Word8 -> IO (Ptr Word8)
 pokeBytesMinus (B.PS foreignPointer offset length) pointer =
   do
     withForeignPtr foreignPointer $ \pointer' ->
-      B.memcpy targetPointer (plusPtr pointer' offset) length
+      copyBytes targetPointer (plusPtr pointer' offset) length
     pure targetPointer
   where
     targetPointer =

--- a/library/ByteString/TreeBuilder/Prelude.hs
+++ b/library/ByteString/TreeBuilder/Prelude.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module ByteString.TreeBuilder.Prelude
 ( 
   module Exports,
@@ -28,7 +29,11 @@ import Data.Either as Exports
 import Data.Fixed as Exports
 import Data.Foldable as Exports hiding (toList)
 import Data.Function as Exports hiding (id, (.))
+#if MIN_VERSION_base(4,19,0)
+import Data.Functor as Exports hiding (unzip)
+#else
 import Data.Functor as Exports
+#endif
 import Data.Functor.Compose as Exports
 import Data.Int as Exports
 import Data.IORef as Exports


### PR DESCRIPTION
- Avoid error due to `unzip` import conflict with new Data.Functor.unzip
- Avoid warnings for non-canonical mappend
- Avoid warnings for use of now-deprecated memcpy

* The deprecation of `memcpy` is new with `bytestring-0.11.5`
* The `unzip` issue is new with `base-4.19.0`. It affects similar Preludes in at least:

    - `bytestring-tree-builder-0.2.7.10`
    - `contravariant-extras-0.3.5.3`
    - `hasql-1.6.3.2`
    - `hasql-pool-0.10`
    - `hasql-transaction-1.0.1.2`
    - `isomorphism-class-0.1.0.10`
    - `postgresql-binary-0.13.1`
    - `template-haskell-compat-v0208-0.1.9.2`
    - `text-builder-0.6.7`
    - `text-builder-dev-0.3.3.2`